### PR TITLE
feat: Add logging to PluginSystem initialization process

### DIFF
--- a/Megasware128.GTA.Runtime/Megasware128.GTA.Runtime.csproj
+++ b/Megasware128.GTA.Runtime/Megasware128.GTA.Runtime.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.7.40" />
+    <PackageReference Include="NReco.Logging.File" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Initialize a FileLoggerProvider with the entryAssembly name for logging
- Log messages for creating plugin directory, loading plugins, and initializing
  plugins
- Log errors for any issues during plugin discovery and composition
- Log total number of initialized plugins
- Update project file to include NReco.Logging.File package

This commit enhances the PluginSystem with logging capabilities to provide 
better visibility into the initialization process and potential errors.