### PR TITLE
refactor: Update message handling to use msclr::interop in source/messages.cpp and source/hud.cpp

### DIFF
--- a/source/hud.cpp
+++ b/source/hud.cpp
@@ -3,19 +3,20 @@
 #pragma unmanaged
 #include "CHud.h"
 
-static void addHelpMessage(char* message, bool quick, bool permanent) {
+static void addHelpMessage(const char* message, bool quick, bool permanent) {
 	CHud::SetHelpMessage(message, quick, permanent, false);
 }
 
 #pragma managed
+#include <msclr/marshal.h>
+
+using namespace msclr::interop;
 
 using namespace System;
 using namespace System::Runtime::InteropServices;
 using namespace Megasware128::GTA::Abstractions::Game;
 
 void Hud::ShowHelpMessage(String^ message, bool quick, bool permanent) {
-	IntPtr ptr = Marshal::StringToHGlobalAnsi(message);
-	char* str = static_cast<char*>(ptr.ToPointer());
-	addHelpMessage(str, quick, permanent);
-	Marshal::FreeHGlobal(ptr);
+	marshal_context context;
+	addHelpMessage(context.marshal_as<const char*>(message), quick, permanent);
 }

--- a/source/messages.cpp
+++ b/source/messages.cpp
@@ -3,14 +3,16 @@
 #pragma unmanaged
 #include "CMessages.h"
 
-static void addMessage(char* message, int duration) {
-	CMessages::AddMessageJumpQ(message, duration, 0, false);
+static void addMessage(const char* message, int duration) {
+	CMessages::AddMessageJumpQ(const_cast<char*>(message), duration, 0, false);
 }
 
 #pragma managed
+#include <msclr/marshal.h>
+
+using namespace msclr::interop;
 
 using namespace System;
-using namespace System::Runtime::InteropServices;
 using namespace Megasware128::GTA::Abstractions::Game;
 
 void Messages::Show(String^ message) {
@@ -18,8 +20,6 @@ void Messages::Show(String^ message) {
 }
 
 void Messages::Show(String^ message, int duration) {
-	IntPtr ptr = Marshal::StringToHGlobalAnsi(message);
-	char* str = static_cast<char*>(ptr.ToPointer());
-	addMessage(str, duration);
-	Marshal::FreeHGlobal(ptr);
+	marshal_context^ context = gcnew marshal_context();
+	addMessage(context->marshal_as<const char*>(message), duration);
 }


### PR DESCRIPTION
Refactored the message handling functions in source/messages.cpp and source/hud.cpp to use msclr::interop for better interoperability with managed and unmanaged code. Updated addMessage and addHelpMessage functions to use const char* parameters and marshal the managed strings appropriately. Removed unnecessary manual memory management.